### PR TITLE
Smarter detection of removed opportunities.

### DIFF
--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/OpportunityDAO.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/OpportunityDAO.java
@@ -6,6 +6,7 @@ import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
 import uk.andrewgorton.digitalmarketplace.alerter.dao.mappers.OpportunityMapper;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 @RegisterMapper(OpportunityMapper.class)
@@ -60,8 +61,8 @@ public interface OpportunityDAO {
     @SqlUpdate("update opportunity set removed = :removed where id = :id")
     void setRemoved(@Bind("removed") boolean isRemoved, @Bind("id") long id);
 
-    @SqlQuery("select * from opportunity where removed = false order by published desc limit 100")
-    List<Opportunity> findAllUnremoved();
+    @SqlQuery("select * from opportunity where closed = false and removed = false and lastUpdated < :notUpdatedSince limit 100")
+    List<Opportunity> findAllNotUpdatedSince(@Bind("notUpdatedSince") Timestamp notUpdatedSince);
 
     @SqlUpdate("insert into bidmanager_session (opportunity, key) values (:opportunity, :key)")
     void insertKey(@Bind("opportunity") Long opportunityId, @Bind("key") String key);

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -244,4 +244,10 @@
                               columnDataType="boolean"
                               defaultNullValue="false"/>
     </changeSet>
+
+    <changeSet id="11" author="andrewg">
+        <update tableName="opportunity">
+            <column name="removed" type="boolean" value="false"/>
+        </update>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Works by only detecting opportunities which have not updated in 2 hours (4
polls). Then checks for 404s at the URL. Had to reset the flag as the
previous method was less smart and all closed opportunities got flagged as
removed.